### PR TITLE
[BUGFIX] Allow '@' sign in text

### DIFF
--- a/typoscript.py
+++ b/typoscript.py
@@ -182,7 +182,7 @@ class TypoScriptLexer(RegexLexer):
             (r'(\s*#\s*\n)', Comment),
         ],
         'other': [
-            (r'[\w"\-_!\/&;]+', Text),
+            (r'[\w"\-_!\/&;@]+', Text),
         ],
     }
 


### PR DESCRIPTION
Hi Michiel, great that Ernesto found out today what's the reason that some TypoScripts couldn't be lexed. The @ sign in emails is the culprit. So we add it to the allowed characters. Actually, I havent finally tested the files from this repository. But we soon will know that and if the patch is ok.

Can you make it go into the official Pygments distribution then?

Would be cool.
